### PR TITLE
Fix compatibility with composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 
-    "name": "oat/NBCOT",
+    "name": "oat/nbcot",
     "description" : "",
     "type" : "tao-extension",
     "authors" : [


### PR DESCRIPTION
Composer 2.0 will be released soon and usage of package names in uppercase doesn't look valid from their perspective. To avoid breaking deployment and other processes it makes sense to adjust the name in advance.